### PR TITLE
Update CurseForge link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ JustAC reads Blizzard's built-in Combat Assistant suggestions (`C_AssistedCombat
 
 ## Installation
 
-1. Download from [CurseForge](https://www.curseforge.com/wow/addons/justac) or extract to `Interface\AddOns\JustAC`
+1. Download from [CurseForge](https://www.curseforge.com/wow/addons/just-assisted-combat) or extract to `Interface\AddOns\JustAC`
 2. Enable "Assisted Combat" in WoW's Game Menu → Edit Mode → Combat section
 3. `/jac` to access options
 


### PR DESCRIPTION
CurseForge link in README.md returns a 404. Updated the link to what appears to be the correct addon on CurseForge (https://www.curseforge.com/wow/addons/just-assisted-combat).